### PR TITLE
Add /gollum/create to the list of "write paths"

### DIFF
--- a/lib/gollum/auth/request.rb
+++ b/lib/gollum/auth/request.rb
@@ -3,7 +3,7 @@ module Gollum::Auth
     WRITE_PATH_RE = %r{
       ^/
       (gollum/)? # This path prefix was introduced in Gollum 5
-      (create/|edit/|delete/|rename/|revert/|uploadFile$|upload_file$)
+      (create$|create/|edit/|delete/|rename/|revert/|uploadFile$|upload_file$)
     }x
 
     def requires_authentication?(allow_unauthenticated_readonly)


### PR DESCRIPTION
This path is used when creating the home page in a new empty wiki and
should require authentication too.