### PR TITLE
Remove activemodel gem version restriction

### DIFF
--- a/gollum-auth.gemspec
+++ b/gollum-auth.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rack'
-  spec.add_dependency 'activemodel', '~> 4.2'
+  spec.add_dependency 'activemodel'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Using the old version results in conflicts when running "bundle install"
and the new one seems to work just as well, so allow installing any
version of it.

----

Sorry if this is not the right thing to do, I'm not at all a Ruby expert (IOW I don't know anything about it), but I couldn't install this gem without this change using bundler 2.2 and ruby 2.7 (Debian 11).