### PR TITLE
Use lower-case header names to pacify Rack::Lint

### DIFF
--- a/lib/gollum/auth.rb
+++ b/lib/gollum/auth.rb
@@ -37,8 +37,8 @@ module Gollum
         [
           401,
           {
-            'Content-Type'     => 'text/plain',
-            'WWW-Authenticate' => 'Basic realm="Gollum Wiki"'
+            'content-type'     => 'text/plain',
+            'www-authenticate' => 'Basic realm="Gollum Wiki"'
           },
           [ 'Not authorized' ]
         ]


### PR DESCRIPTION
Using "Content-Type" header results in a Rack::Lint::LintError complaining about "uppercase character in header name: Content-Type" with rack 3, see

https://github.com/rack/rack/blob/744f92d099653f873ced3380e425a6f82f0c6c6c/UPGRADE-GUIDE.md?plain=1#L16